### PR TITLE
Allow For higher Versions of websockets

### DIFF
--- a/custom_components/hypervolt_charger/manifest.json
+++ b/custom_components/hypervolt_charger/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gndean/home-assistant-hypervolt-charger/issues",
-  "requirements": ["websockets>=11.0.3", "websockets<=14.0", "aiofiles==24.1.0"],
+  "requirements": ["websockets>=11.0.3,<14", "aiofiles==24.1.0"],
   "version": "2.3.5"
 }

--- a/custom_components/hypervolt_charger/manifest.json
+++ b/custom_components/hypervolt_charger/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gndean/home-assistant-hypervolt-charger/issues",
-  "requirements": ["websockets>=11.0.3", "aiofiles==24.1.0"],
+  "requirements": ["websockets<=14.0", "aiofiles==24.1.0"],
   "version": "2.3.5"
 }

--- a/custom_components/hypervolt_charger/manifest.json
+++ b/custom_components/hypervolt_charger/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gndean/home-assistant-hypervolt-charger/issues",
-  "requirements": ["websockets<=14.0", "aiofiles==24.1.0"],
+  "requirements": ["websockets>=11.0.3", "websockets<=14.0", "aiofiles==24.1.0"],
   "version": "2.3.5"
 }

--- a/custom_components/hypervolt_charger/manifest.json
+++ b/custom_components/hypervolt_charger/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gndean/home-assistant-hypervolt-charger/issues",
-  "requirements": ["websockets==11.0.3", "aiofiles==24.1.0"],
+  "requirements": ["websockets>=11.0.3", "aiofiles==24.1.0"],
   "version": "2.3.5"
 }


### PR DESCRIPTION
strict requirement prevents some core integrations from updating to higher versions which they require. Discovered when ring integration failed after 2024.11.2 update.

there may be other integrations it causes problems with too

Using higher version does not seem to break anything.

issue first discussed here: https://github.com/home-assistant/core/issues/130725
fixes this issue: https://github.com/gndean/home-assistant-hypervolt-charger/issues/79