### PR TITLE
Allow for Websockets 15.1 to be used so integration loads on home assistant 2025.8

### DIFF
--- a/custom_components/hypervolt_charger/manifest.json
+++ b/custom_components/hypervolt_charger/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gndean/home-assistant-hypervolt-charger/issues",
-  "requirements": ["websockets>=11.0.03,<15", "aiofiles==24.1.0"],
+  "requirements": ["websockets>=11.0.03,<15.1", "aiofiles==24.1.0"],
   "version": "2.4.1"
 }


### PR DESCRIPTION
PR to make the change recomended by @DavidGeorge528 in https://github.com/gndean/home-assistant-hypervolt-charger/issues/94

As with David, I have not extensivly dived into the changes of websockets 15.0 to 15.1, however things seem to work with the integration as far as i can see.

perhaps others can test to make sure there are no issues that I havent come across.