### PR TITLE
Avoid os.scandir blocking call

### DIFF
--- a/custom_components/hypervolt_charger/hypervolt_update_coordinator.py
+++ b/custom_components/hypervolt_charger/hypervolt_update_coordinator.py
@@ -50,6 +50,7 @@ class HypervoltUpdateCoordinator(DataUpdateCoordinator[HypervoltDeviceState]):
         # Load any drop-in LED effect definitions for use by the light platform.
         # This is best-effort; failures should not prevent the integration loading.
         coordinator.led_effect_definitions = await async_load_led_effect_definitions(
+            hass,
             (Path(__file__).resolve().parent / "led_effects")
         )
 

--- a/custom_components/hypervolt_charger/led_effects.py
+++ b/custom_components/hypervolt_charger/led_effects.py
@@ -26,6 +26,8 @@ from typing import Any
 import aiofiles
 import yaml
 
+from homeassistant.core import HomeAssistant
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -172,17 +174,21 @@ def _parse_definition(
     return None
 
 
+def _get_effect_paths(effects_dir: Path) -> list[Path]:
+    if not effects_dir.exists() or not effects_dir.is_dir():
+        return []
+    return [*effects_dir.glob("*.yaml"), *effects_dir.glob("*.yml")]
+
+
 async def async_load_led_effect_definitions(
+    hass: HomeAssistant,
     effects_dir: Path,
 ) -> dict[str, LedEffectDefinition]:
     """Load LED effect definitions from the given directory."""
 
-    if not effects_dir.exists() or not effects_dir.is_dir():
-        return {}
-
     definitions: dict[str, LedEffectDefinition] = {}
 
-    paths = [*effects_dir.glob("*.yaml"), *effects_dir.glob("*.yml")]
+    paths = await hass.async_add_executor_job(_get_effect_paths, effects_dir)
 
     for path in sorted(paths):
         try:


### PR DESCRIPTION
As part of the load led effect - we are using a call to os.scandir - which is flagging in the logs as causing a blocking call at startup.

Extract the method and add it to the assync exectutor.

Am not wholly confident that this will work straight away (am simply following https://developers.home-assistant.io/docs/asyncio_blocking_operations/#scandir ) but worth putting forward a first fix effort!